### PR TITLE
Build fix and make resource-agnostic

### DIFF
--- a/_build/resolvers/resolve.tables.php
+++ b/_build/resolvers/resolve.tables.php
@@ -25,6 +25,10 @@
  * @package rampart
  * @subpackage build
  */
+/* @var $object
+ * @var modX $modx
+ * @var array $options 
+ */ 
 if ($object->xpdo) {
     switch ($options[xPDOTransport::PACKAGE_ACTION]) {
         case xPDOTransport::ACTION_INSTALL:
@@ -37,6 +41,7 @@ if ($object->xpdo) {
             $m->createObjectContainer('rptBan');
             $m->createObjectContainer('rptFlaggedUser');
             $m->createObjectContainer('rptBanMatch');
+            $m->createObjectContainer('rptBanMatchField');
             $m->createObjectContainer('rptBanMatchBan');
             $m->createObjectContainer('rptWhiteList');
             break;

--- a/core/components/rampart/model/rampart/rampart.class.php
+++ b/core/components/rampart/model/rampart/rampart.class.php
@@ -459,7 +459,7 @@ class Rampart {
             if (!empty($fields['hostname'])) { $match->set('hostname_match',$fields['hostname']); }
             if (!empty($fields['email'])) { $match->set('email_match',$fields['email']); }
 
-            $match->set('resource',$this->modx->resource->get('id'));
+            $match->set('resource',($this->modx->resource) ? $this->modx->resource->get('id') : 0);
             $match->set('data',$result);
             $match->set('service',!empty($result[Rampart::SERVICE]) ? $result[Rampart::SERVICE] : 'manual');
             $match->set('notes',!empty($result[Rampart::NOTES]) ? $result[Rampart::NOTES] : '');


### PR DESCRIPTION
- Add missing createObjectContainer call in tables resolver for ban matches
- Make sure calling Rampart::addBan doesn't break when $modx->resource is null. Need this fix to allow Notify404 to add a ban (match) from the OnPageNotFound event.
