### PR TITLE
Ability to monitor incoming requests against the ban list.

### DIFF
--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -103,7 +103,7 @@ $settings['rampart.denyaccess']->fromArray(array(
 $settings['rampart.denyaccess.threshold']= $modx->newObject('modSystemSetting');
 $settings['rampart.denyaccess.threshold']->fromArray(array(
     'key' => 'rampart.denyaccess.threshold',
-    'value' => false,
+    'value' => 5,
     'xtype' => 'textfield',
     'namespace' => 'rampart',
     'area' => 'Deny Access',

--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -92,5 +92,21 @@ $settings['rampart.honeypot.fullwall_enabled']->fromArray(array(
     'namespace' => 'rampart',
     'area' => 'HoneyPot',
 ),'',true,true);
+$settings['rampart.denyaccess']= $modx->newObject('modSystemSetting');
+$settings['rampart.denyaccess']->fromArray(array(
+    'key' => 'rampart.denyaccess',
+    'value' => false,
+    'xtype' => 'combo-boolean',
+    'namespace' => 'rampart',
+    'area' => 'Deny Access',
+),'',true,true);
+$settings['rampart.denyaccess.threshold']= $modx->newObject('modSystemSetting');
+$settings['rampart.denyaccess.threshold']->fromArray(array(
+    'key' => 'rampart.denyaccess.threshold',
+    'value' => false,
+    'xtype' => 'textfield',
+    'namespace' => 'rampart',
+    'area' => 'Deny Access',
+),'',true,true);
 
 return $settings;

--- a/core/components/rampart/lexicon/en/default.inc.php
+++ b/core/components/rampart/lexicon/en/default.inc.php
@@ -128,3 +128,9 @@ $_lang['setting_rampart.honeypot.blhost'] = 'ProjectHoneyPot Blacklist Host';
 $_lang['setting_rampart.honeypot.blhost_desc'] = 'The hostname for the Project Honey Pot Blacklist service.';
 $_lang['setting_rampart.honeypot.fullwall_enabled'] = 'Enable ProjectHoneyPot Full Wall Blacklist';
 $_lang['setting_rampart.honeypot.fullwall_enabled_desc'] = 'If true, will enable Blacklist banning for your site that will completely prevent site viewing, via Project Honey Pot.';
+
+$_lang['setting_rampart.denyaccess'] = 'Deny Access when Banned';
+$_lang['setting_rampart.denyaccess_desc'] = 'If true, this will deny access to anyone requestion any page on your site that appears on the ban list. ';
+
+$_lang['setting_rampart.denyaccess.threshold'] = 'Deny Access Threshold';
+$_lang['setting_rampart.denyaccess.threshold_desc'] = 'When Deny Access when Banned is enabled, access is denied when ban has seen more than the threshold amount of matches.';


### PR DESCRIPTION
Update plugin to monitor requests against the ban list, allowing to deny access to the site entirely at a certain threshold of ban matches. Threshold defaults to 5, so it needs 5 ban matches before blocking access to the site. 

A ban match is anything from a spam comment to an StopForumSpam or HoneyPot match (if enabled), and I've expanded Notify404 to add a ban match when it finds a known hack attempt / sniffing - specifically the Evo reflect_base exploit and various synonyms of phpmyadmin. Valid phpmyadmin requests (just in case) wouldn't be picked up by MODX, so Notify404 wouldn't add a ban match for that. 

_note_ I've only tested this locally (so far so good!) on a 2.2 install from Git. Will be deploying & further testing this (specifically with Notify404) on a 2.1 install (my own site) and an older 2.2 (client) later this/next week. Both are being troubled by scriptkiddies sniffing for phpmyadmin, so should be a good test case.
